### PR TITLE
Context

### DIFF
--- a/include/algorithm.h
+++ b/include/algorithm.h
@@ -38,11 +38,6 @@ private:
 
     void setSearchTime(double);
     void setNumRecur(int);
-    
-	//parameters: [aG1], [aG2]
-	//VERIFY whether aG1 and aG2 has same number of vertices for each degree and label
-	//RETURN true if the condition is satisfied, false otherwise
-	//bool checkSimpleInvariants(Graph*, Graph*);
 };
 
 #endif

--- a/include/algorithm.h
+++ b/include/algorithm.h
@@ -42,7 +42,7 @@ private:
 	//parameters: [aG1], [aG2]
 	//VERIFY whether aG1 and aG2 has same number of vertices for each degree and label
 	//RETURN true if the condition is satisfied, false otherwise
-	bool checkSimpleInvariants(Graph*, Graph*);
+	//bool checkSimpleInvariants(Graph*, Graph*);
 };
 
 #endif

--- a/include/backtrack.h
+++ b/include/backtrack.h
@@ -24,11 +24,6 @@
 
 using namespace std;
 
-//extern vector<int32_t> global_temp_vector;
-//extern int32_t* markNode;
-//extern int32_t* markCell;
-//extern int32_t global_mark;
-
 class Backtrack
 {
     double searchTime;

--- a/include/backtrack.h
+++ b/include/backtrack.h
@@ -6,6 +6,7 @@
 // Author: Geonmo Gu
 // Version
 //     August 20, 2020: the first stable version. (version 1.0)
+//     October 20, 2020: use Context class
 //***************************************************************************
 
 #ifndef __BACKTRACK_H__
@@ -19,14 +20,14 @@
 #include "cs.h"
 #include "heap.h"
 #include "memory.h"
-#include "global.h"
+#include "global.h" //context
 
 using namespace std;
 
-extern vector<int32_t> global_temp_vector;
-extern int32_t* markNode;
-extern int32_t* markCell;
-extern int32_t global_mark;
+//extern vector<int32_t> global_temp_vector;
+//extern int32_t* markNode;
+//extern int32_t* markCell;
+//extern int32_t global_mark;
 
 class Backtrack
 {
@@ -62,6 +63,14 @@ class Backtrack
 	int32_t* candPos = NULL;
 	int32_t* matchingOrder = NULL;
 	char* isBinary = NULL;
+	vector<int32_t> global_temp_vector;
+
+	//context variables (do not free)
+	Memory* global_memory = NULL;
+	int32_t* markNode = NULL;
+	int32_t* markCell = NULL;
+	int32_t global_mark = 0;
+	
 	
 	//ALLOCATE memory for each workspace variables
 	void initWorkspace();
@@ -138,7 +147,7 @@ class Backtrack
     void setSearchTime(double);
     void increaseNumRecur();
 public:
-	Backtrack();
+	Backtrack(Context&);
 	~Backtrack();
 
     double getSearchTime();

--- a/include/global.h
+++ b/include/global.h
@@ -24,10 +24,10 @@ using namespace std;
 
 //parameter: [the number of vertices in g1]
 //ALLOCATE global variables
-void initGlobal(int32_t);
+//void initGlobal(int32_t);
 
 //DEALLOCATE global variables
-void clearGlobal();
+//void clearGlobal();
 
 class Context{
 public:
@@ -35,7 +35,7 @@ public:
 	int32_t* markNode = NULL;
 	int32_t global_mark = 0;
 	Memory global_memory;
-	vector<int32_t> global_temp_vector;
+	//vector<int32_t> global_temp_vector;
 
 
 	Context();

--- a/include/global.h
+++ b/include/global.h
@@ -22,24 +22,20 @@ using namespace std;
 #define INFINITY 2000000000
 #define INIT_FSIZE 8
 
-//parameter: [the number of vertices in g1]
-//ALLOCATE global variables
-//void initGlobal(int32_t);
-
-//DEALLOCATE global variables
-//void clearGlobal();
-
 class Context{
 public:
 	int32_t* markCell = NULL;
 	int32_t* markNode = NULL;
 	int32_t global_mark = 0;
 	Memory global_memory;
-	//vector<int32_t> global_temp_vector;
-
 
 	Context();
+
+	//parameter: [the number of vertices in g1]
+	//ALLOCATE global variables
 	void init(int32_t);
+
+	//DEALLOCATE global variables
 	void clear();
 };
 

--- a/include/refine.h
+++ b/include/refine.h
@@ -39,11 +39,6 @@
 
 using namespace std;
 
-//extern Memory global_memory;
-//extern int32_t* markCell;
-//extern int32_t* markNode;
-//extern int32_t global_mark;
-
 class Refinement
 {
 	Coloring* stableColoring = NULL;

--- a/include/refine.h
+++ b/include/refine.h
@@ -6,6 +6,7 @@
 // Author: Geonmo Gu, Yehyun Nam
 // Version
 //     August 20, 2020: the first stable version. (version 1.0)
+//     October 20, 2020: use Context class
 //***************************************************************************
 
 #ifndef __REFINE_H__
@@ -38,10 +39,10 @@
 
 using namespace std;
 
-extern Memory global_memory;
-extern int32_t* markCell;
-extern int32_t* markNode;
-extern int32_t global_mark;
+//extern Memory global_memory;
+//extern int32_t* markCell;
+//extern int32_t* markNode;
+//extern int32_t global_mark;
 
 class Refinement
 {
@@ -63,6 +64,12 @@ class Refinement
 	int32_t* splitCount = NULL;
 	int32_t* splitPos = NULL;
 
+	//Context variables
+	Memory* global_memory = NULL;
+	int32_t* markCell = NULL;
+	int32_t* markNode = NULL;
+	int32_t global_mark = 0;
+	
 
 	//ALLOCATE memory for each workspace variables
 	void initWorkspace();
@@ -102,7 +109,7 @@ class Refinement
 	void deleteEdge(int32_t, int32_t, Graph*, Graph*);
 
 public:
-	Refinement();
+	Refinement(Context&);
 	~Refinement();
 
 	//parameters: [aG1], [aG2]

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -6,6 +6,7 @@
 // Author: Geonmo Gu, Yehyun Nam
 // Version
 //     August 20, 2020: the first stable version. (version 1.0)
+//     October 20, 2020: use Context class
 //***************************************************************************
 
 #include "algorithm.h"
@@ -41,14 +42,16 @@ bool Algorithm::run(Graph* aG1, Graph* aG2)
 	cout << __PRETTY_FUNCTION__ << endl;
 	#endif
 
-	initGlobal(aG1->numNode);
+	Context cont;
+	cont.init(aG1->numNode);
+	//initGlobal(aG1->numNode);
 
 	// bool result = checkSimpleInvariants(aG1, aG2);
 	// if (result == false) {
 	// 	return false;
 	// }
 
-	Refinement cr;
+	Refinement cr(cont);
 	bool result = cr.run(aG1, aG2);
 	if (result == false) {
 		return false;
@@ -56,16 +59,17 @@ bool Algorithm::run(Graph* aG1, Graph* aG2)
 
 	Coloring* coloring = cr.getStableColoring();
 
-	Backtrack bt;
+	Backtrack bt(cont);
 	result = bt.run(coloring, aG1, aG2, cr.getNumTreeNode());
     setSearchTime(bt.getSearchTime());
     setNumRecur(bt.getNumRecur());
 
-	clearGlobal();
+	cont.clear();
+	//clearGlobal();
 
 	return result;
 }
-
+/*
 //VERIFY whether aG1 and aG2 has same number of vertices for each degree and label
 //RETURN true if the condition is satisfied, false otherwise
 bool Algorithm::checkSimpleInvariants(Graph* aG1, Graph* aG2)
@@ -115,4 +119,4 @@ bool Algorithm::checkSimpleInvariants(Graph* aG1, Graph* aG2)
 
 	return true;
 }
-
+*/

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -44,12 +44,6 @@ bool Algorithm::run(Graph* aG1, Graph* aG2)
 
 	Context cont;
 	cont.init(aG1->numNode);
-	//initGlobal(aG1->numNode);
-
-	// bool result = checkSimpleInvariants(aG1, aG2);
-	// if (result == false) {
-	// 	return false;
-	// }
 
 	Refinement cr(cont);
 	bool result = cr.run(aG1, aG2);
@@ -65,58 +59,6 @@ bool Algorithm::run(Graph* aG1, Graph* aG2)
     setNumRecur(bt.getNumRecur());
 
 	cont.clear();
-	//clearGlobal();
 
 	return result;
 }
-/*
-//VERIFY whether aG1 and aG2 has same number of vertices for each degree and label
-//RETURN true if the condition is satisfied, false otherwise
-bool Algorithm::checkSimpleInvariants(Graph* aG1, Graph* aG2)
-{
-	#ifdef DEBUG
-	cout << __PRETTY_FUNCTION__ << endl;
-	#endif
-
-	if (aG1->numNode != aG2->numNode)
-		return false;
-	if (aG1->numEdge != aG2->numEdge)
-		return false;
-
-	const int32_t numNode = aG1->numNode;
-
-	int32_t* nodes1 = global_memory.getLLArray(numNode);
-	int32_t* nodes2 = global_memory.getLLArray(numNode);
-
-	for (int32_t i = 0; i < numNode; ++i)
-		nodes1[i] = nodes2[i] = i;
-
-	sort(nodes1, nodes1 + numNode,
-			[aG1](const int32_t& i, const int32_t& j) -> bool {
-				if (aG1->d[i] == aG1->d[j])
-					return aG1->l[i] < aG1->l[j];
-
-				return aG1->d[i] < aG1->d[j];
-			});
-
-	sort(nodes2, nodes2 + numNode,
-			[aG2](const int32_t& i, const int32_t& j) -> bool {
-				if (aG2->d[i] == aG2->d[j])
-					return aG2->l[i] < aG2->l[j];
-
-				return aG2->d[i] < aG2->d[j];
-			});
-
-	for (int32_t i = 0; i < numNode; ++i) {
-		if (aG1->d[nodes1[i]] != aG2->d[nodes2[i]])
-			return false;
-		if (aG1->l[nodes1[i]] != aG2->l[nodes2[i]])
-			return false;
-	}
-
-	global_memory.returnLLArray(nodes1, numNode);
-	global_memory.returnLLArray(nodes2, numNode);
-
-	return true;
-}
-*/

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -12,50 +12,6 @@
 #include <cstring>
 
 #include "global.h"
-/*
-vector<int32_t> global_temp_vector;
-int32_t* markCell = NULL;
-int32_t* markNode = NULL;
-int32_t global_mark = 0;
-Memory global_memory;
-
-//note that aNumNode is the number of vertices in g1.
-//ALLOCATE global variables
-void initGlobal(int32_t aNumNode)
-{
-	#ifdef DEBUG
-	cout << __PRETTY_FUNCTION__ << endl;
-	#endif
-
-	clearGlobal(); //avoid double allocation
-
-	int32_t n2 = aNumNode * 2;
-
-	markCell = new int32_t[n2];
-	markNode = new int32_t[n2];
-
-	memset(markCell, 0, sizeof(int32_t) * n2);
-	memset(markNode, 0, sizeof(int32_t) * n2);
-
-	global_mark = 1;
-}
-
-//DEALLOCATE global variables
-void clearGlobal()
-{
-	#ifdef DEBUG
-	cout << __PRETTY_FUNCTION__ << endl;
-	#endif
-
-	if( markCell != NULL ) {
-		delete[] markCell;
-		markCell = NULL;
-	}
-	if( markNode != NULL ) {
-		delete[] markNode;
-		markNode = NULL;
-	}
-}*/
 
 Context::Context()
 {
@@ -99,6 +55,4 @@ void Context::clear()
 		delete[] markNode;
 		markNode = NULL;
 	}
-
-	//global_temp_vector.clear();
 }

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -12,7 +12,7 @@
 #include <cstring>
 
 #include "global.h"
-
+/*
 vector<int32_t> global_temp_vector;
 int32_t* markCell = NULL;
 int32_t* markNode = NULL;
@@ -55,7 +55,7 @@ void clearGlobal()
 		delete[] markNode;
 		markNode = NULL;
 	}
-}
+}*/
 
 Context::Context()
 {
@@ -100,5 +100,5 @@ void Context::clear()
 		markNode = NULL;
 	}
 
-	global_temp_vector.clear();
+	//global_temp_vector.clear();
 }

--- a/src/refine.cpp
+++ b/src/refine.cpp
@@ -6,13 +6,20 @@
 // Author: Geonmo Gu, Yehyun Nam
 // Version
 //     August 20, 2020: the first stable version. (version 1.0)
+//     October 20, 2020: use Context class
 //***************************************************************************
 
 #include "refine.h"
 
 #include <cassert>
 
-Refinement::Refinement() {}
+Refinement::Refinement(Context& aContext) 
+{
+	global_memory = &(aContext.global_memory);
+	markCell = aContext.markCell;
+	markNode = aContext.markNode;
+	global_mark = aContext.global_mark;
+}
 
 Refinement::~Refinement()
 {
@@ -90,15 +97,15 @@ void Refinement::initWorkspace()
 
 	clearWorkspace(); //avoid double allocation
 
-	cellStack = global_memory.getLLArray(n2);
+	cellStack = global_memory->getLLArray(n2);
 	stackSize = 0;
-	neighCount = global_memory.getLLArray(n2);
-	visitCell = global_memory.getLLArray(n2);
-	visitNode = global_memory.getLLArray(n2);
-	numVisitNode = global_memory.getLLArray(n2);
-	splitCell = global_memory.getLLArray(n2);
-	splitCount = global_memory.getLLArray(n2);
-	splitPos = global_memory.getLLArray(n2);
+	neighCount = global_memory->getLLArray(n2);
+	visitCell = global_memory->getLLArray(n2);
+	visitNode = global_memory->getLLArray(n2);
+	numVisitNode = global_memory->getLLArray(n2);
+	splitCell = global_memory->getLLArray(n2);
+	splitCount = global_memory->getLLArray(n2);
+	splitPos = global_memory->getLLArray(n2);
 }
 
 //DEALLOCATE memory for each workspace variables
@@ -109,35 +116,35 @@ void Refinement::clearWorkspace()
 	#endif
 
 	if (cellStack != NULL) {
-		global_memory.returnLLArray(cellStack, n2);
+		global_memory->returnLLArray(cellStack, n2);
 		cellStack = NULL;
 	}
 	if (neighCount != NULL) {
-		global_memory.returnLLArray(neighCount, n2);
+		global_memory->returnLLArray(neighCount, n2);
 		neighCount = NULL;
 	}
 	if (visitCell != NULL) {
-		global_memory.returnLLArray(visitCell, n2);
+		global_memory->returnLLArray(visitCell, n2);
 		visitCell = NULL;
 	}
 	if (visitNode != NULL) {
-		global_memory.returnLLArray(visitNode, n2);
+		global_memory->returnLLArray(visitNode, n2);
 		visitNode = NULL;
 	}
 	if (numVisitNode != NULL) {
-		global_memory.returnLLArray(numVisitNode, n2);
+		global_memory->returnLLArray(numVisitNode, n2);
 		numVisitNode = NULL;
 	}
 	if (splitCell != NULL) {
-		global_memory.returnLLArray(splitCell, n2);
+		global_memory->returnLLArray(splitCell, n2);
 		splitCell = NULL;
 	}
 	if (splitCount != NULL) {
-		global_memory.returnLLArray(splitCount, n2);
+		global_memory->returnLLArray(splitCount, n2);
 		splitCount = NULL;
 	}
 	if (splitPos != NULL) {
-		global_memory.returnLLArray(splitPos, n2);
+		global_memory->returnLLArray(splitPos, n2);
 		splitPos = NULL;
 	}
 }
@@ -237,8 +244,8 @@ bool Refinement::refine(Coloring* coloring, Graph* aG1, Graph* aG2)
 
 	const int32_t numNode = aG1->numNode + aG2->numNode;
 
-	int32_t* inStack = global_memory.getLLArray(numNode);
-	int32_t* stackCand = global_memory.getLLArray(numNode);
+	int32_t* inStack = global_memory->getLLArray(numNode);
+	int32_t* stackCand = global_memory->getLLArray(numNode);
 
 	memset(inStack, 0, sizeof(int32_t) * numNode);
 	memset(stackCand, 0, sizeof(int32_t) * numNode);


### PR DESCRIPTION
I created Context class in global.hpp.
Context class contains mark variables and memory manager, which were global variables declared in global.hpp.
Now we access globally-used variables by an instance of Context class, instead of direct access of them using extern keyword.
This change will prevent a possible bug that can be occur when we publish GI library.
Thanks to [charsyam](https://github.com/charsyam) for the constructive comment.